### PR TITLE
Celery task logging in place of blueprints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - TOXENV=py35
 install:
     - pip install -U pip
-    - pip install -U Flask tox coverage codecov
+    - pip install -U Flask tox coverage codecov celery
 script:
     - tox
 after_success:

--- a/flask_logging_extras/__init__.py
+++ b/flask_logging_extras/__init__.py
@@ -32,6 +32,11 @@ no value is present in the message record.
 
 import logging
 
+try:
+    from celery import current_task:
+except ImportError:
+    current_task = None
+
 from flask import has_request_context, request
 
 __version_info__ = ('0', '0', '1')
@@ -134,7 +139,9 @@ class FlaskExtraLogger(logging.getLoggerClass()):
 
         # If we were asked to log the blueprint name, add it to the extra list
         if self._blueprint_var is not None:
-            if has_request_context():
+            if current_task:
+                kwargs['extra'][self._blueprint_var] = current_task.name
+            elif has_request_context():
                 kwargs['extra'][self._blueprint_var] = request.blueprint or self._blueprint_app
             else:
                 kwargs['extra'][self._blueprint_var] = self._blueprint_norequest


### PR DESCRIPTION
When inside a celery task, this allows you to use the task name rather than a blueprint