### PR TITLE
Allow configuration of the logger before the app gets created

### DIFF
--- a/flask_logging_extras/__init__.py
+++ b/flask_logging_extras/__init__.py
@@ -121,7 +121,7 @@ class FlaskExtraLogger(logging.getLoggerClass()):
                 del(kwargs['app'])
 
         self.app = None
-        self._valid_keywords = []
+        self._valid_keywords = {}
         self._blueprint_var = None
         self._blueprint_app = None
         self._blueprint_norequest = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Flask-Logging-Extras provides extra logging functionality for Flask apps.
 from setuptools import setup
 
 setup(name='Flask-Logging-Extras',
-      version='0.1.1',
+      version='0.2.0',
       url='https://github.com/gergelypolonkai/flask-logging-extras',
       license='MIT',
       author='Gergely Polonkai',


### PR DESCRIPTION
This is necessary if `FlaskExtraLogger` is used as the global logger class, as otherwise it won’t know the list of usable keywords.