### PR TITLE
Rework resolvers and configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Flask-Logging-Extras provides extra logging functionality for Flask apps.
 from setuptools import setup
 
 setup(name='Flask-Logging-Extras',
-      version='1.0.0',
+      version='2.0.0',
       url='https://github.com/gergelypolonkai/flask-logging-extras',
       license='MIT',
       author='Gergely Polonkai',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,5 @@
+EXTRA_VAR = 'extra variable'
+
+
+def get_extra_keyword():
+    return 'extra callable'


### PR DESCRIPTION
Configuration is now in under one key, `FLASK_LOGGING_EXTRAS`.  The old `FLASK_LOGGING_EXTRAS_BLUEPRINT` and `FLASK_LOGGING_EXTRAS_KEYWORDS` are under keys `BLUEPRINT` and `RESOLVERS`, respectively.

The old keyword functionality is also reworked; instead of simple default variables, they are now imported.  These new resolvers still support the old functionality; if it is a string that doesn’t denote an importable object, the exact value will be used as a default.

This is a backwards incompatible change, so the version number is bumped to 2.0.0